### PR TITLE
Check for valid predict value

### DIFF
--- a/mindsdb/libs/controllers/mindsdb_controller.py
+++ b/mindsdb/libs/controllers/mindsdb_controller.py
@@ -174,6 +174,9 @@ class MindsDBController:
         :param model_name:
         :return:
         """
+        
+        if not predict:
+            raise ValueError('Please provide valid predict value.')
 
         transaction_type = TRANSACTION_PREDICT
 


### PR DESCRIPTION
Fix #21 issues. This PR adds validation for predict value. If predict value is missing or it's empty string ValidationError will be raised.